### PR TITLE
bugfix/Add enum support in map_inputs()

### DIFF
--- a/unstructured_platform_plugins/etl_uvicorn/api_generator.py
+++ b/unstructured_platform_plugins/etl_uvicorn/api_generator.py
@@ -56,7 +56,7 @@ def generate_fast_api(
     async def run_job(request: InputSchema) -> response_type:
         logger.debug(f"invoking function: {func}")
         input_schema = get_input_schema(func)
-        request_dict = request.dict()
+        request_dict = request.model_dump()
         for k, v in request_dict.items():
             if schema := input_schema.get(k):  # noqa: SIM102
                 if (

--- a/unstructured_platform_plugins/etl_uvicorn/utils.py
+++ b/unstructured_platform_plugins/etl_uvicorn/utils.py
@@ -79,6 +79,7 @@ def get_schema_dict(func) -> dict:
 def map_inputs(func: Callable, raw_inputs: dict[str, Any]) -> dict[str, Any]:
     # deserializes the raw dictionary coming in from the api into the underlying data
     # types expected by the function when being invoked
+    raw_inputs = raw_inputs.copy()
     type_info = get_type_hints(func)
     type_info.pop("return")
     for field_name, type_data in type_info.items():

--- a/unstructured_platform_plugins/etl_uvicorn/utils.py
+++ b/unstructured_platform_plugins/etl_uvicorn/utils.py
@@ -77,6 +77,8 @@ def get_schema_dict(func) -> dict:
 
 
 def map_inputs(func: Callable, raw_inputs: dict[str, Any]) -> dict[str, Any]:
+    # deserializes the raw dictionary coming in from the api into the underlying data
+    # types expected by the function when being invoked
     type_info = get_type_hints(func)
     type_info.pop("return")
     for field_name, type_data in type_info.items():


### PR DESCRIPTION
### Description
The map_inputs() method used to deserialize the raw dict into the appropriate dataclasses and pydantic base models would break if an input was an enum. This adds support for that. 