### PR TITLE
feat: introduce emitting usage data

### DIFF
--- a/unstructured_platform_plugins/etl_uvicorn/api_generator.py
+++ b/unstructured_platform_plugins/etl_uvicorn/api_generator.py
@@ -70,7 +70,10 @@ def generate_fast_api(
 
     async def wrap_fn(func: Callable, kwargs: Optional[dict[str, Any]] = None) -> InvokeResponse:
         request_dict = kwargs if kwargs else {}
-        request_dict["usage"] = usage
+        if "usage" in inspect.signature(func).parameters:
+            request_dict["usage"] = usage
+        else:
+            logger.warning("usage data not an expected parameter, omitting")
         try:
             output = await invoke_func(func=func, kwargs=request_dict)
             return InvokeResponse(usage=usage, status_code=status.HTTP_200_OK, output=output)

--- a/unstructured_platform_plugins/etl_uvicorn/utils.py
+++ b/unstructured_platform_plugins/etl_uvicorn/utils.py
@@ -73,9 +73,9 @@ def get_output_schema(func: Callable) -> dict:
     return response_to_json_schema(get_output_sig(func))
 
 
-def get_schema_dict(func) -> dict:
+def get_schema_dict(func, omit: list[str] = ["usage"]) -> dict:
     return {
-        "inputs": get_input_schema(func),
+        "inputs": get_input_schema(func, omit=omit),
         "outputs": get_output_schema(func),
     }
 

--- a/unstructured_platform_plugins/etl_uvicorn/utils.py
+++ b/unstructured_platform_plugins/etl_uvicorn/utils.py
@@ -53,8 +53,11 @@ def get_plugin_id(instance: Any, method_name: Optional[str] = None) -> str:
     return ref_id
 
 
-def get_input_schema(func: Callable) -> dict:
+def get_input_schema(func: Callable, omit: Optional[list[str]] = None) -> dict:
+
     parameters = get_typed_parameters(func)
+    if omit:
+        parameters = [p for p in parameters if p.name not in omit]
     return parameters_to_json_schema(parameters)
 
 

--- a/unstructured_platform_plugins/schema/usage.py
+++ b/unstructured_platform_plugins/schema/usage.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel
+
+
+# This is a stand in until a supported schema is published external to this repo
+class UsageData(BaseModel):
+    value: int
+    name: str


### PR DESCRIPTION
### Description
The code that wraps the underlying python code for a user also injects a mutable list of type UsageData. This schema is a fill in for now until a more finalized version is published. This allows developers to create code to publish this data without having to manage the overhead of adding it to the fastapi endpoint. This also wraps the core code in a try-except for the user to enforce best practice of emitting usage data no matter what and provide a response code and error text in the body of the response if the underling code failed. 

The pydantic models for the swagger docs are also reflected with the new data. 