### PR TITLE
bugfix/fix model generation on empty schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.0.1
+
+### Enhancements
+
+### Features
+
+### Fixes
+
+* **Model generation when schema is empty fixed** Key error was being thrown when properties not in schema, but this doesn't exist when schema is null. Null check added. 
+
 ## 0.0.0
 
 ### Enhancements

--- a/unstructured_platform_plugins/__version__.py
+++ b/unstructured_platform_plugins/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.0.0"  # pragma: no cover
+__version__ = "0.0.1"  # pragma: no cover

--- a/unstructured_platform_plugins/schema/json_schema.py
+++ b/unstructured_platform_plugins/schema/json_schema.py
@@ -305,6 +305,8 @@ def schema_to_base_model_type(json_type_name, name: str, type_info: dict) -> Typ
 
 def schema_to_base_model(schema: dict, name: str = "reconstructed_model") -> Type[BaseModel]:
     inputs = {}
+    if schema["type"] == "null":
+        return create_model(name)
     properties = schema["properties"]
 
     for k, v in properties.items():


### PR DESCRIPTION
### Description
If the schema is of type `null`, the `properties` won't exist. This breaks out of that logic first if type is `null`, otherwise still expects properties to exist. 