### PR TITLE
feat: add endpoint /job_types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.0.3
+
+### Enhancements
+
+### Features
+
+* **Add a new end point for plugins `/job_types`** This end points lists available job types for the plugin, which can be set in the plugin's settings when building a workflow to choose one of possible many options a plugin provides
+
+### Fixes
+
 ## 0.0.2
 
 ### Enhancements

--- a/unstructured_platform_plugins/__version__.py
+++ b/unstructured_platform_plugins/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.0.2"  # pragma: no cover
+__version__ = "0.0.3"  # pragma: no cover

--- a/unstructured_platform_plugins/etl_uvicorn/api_generator.py
+++ b/unstructured_platform_plugins/etl_uvicorn/api_generator.py
@@ -148,6 +148,13 @@ def generate_fast_api(
         resp = SchemaOutputResponse(inputs=schema["inputs"], outputs=schema["outputs"])
         return resp
 
+    class JobTypesResponse(BaseModel):
+        job_types: list[str]
+
+    @fastapi_app.get("/job_types")
+    async def get_job_types() -> JobTypesResponse:
+        return JobTypesResponse(job_types=getattr(app, "available_job_types", []))
+
     @fastapi_app.get("/precheck")
     async def run_precheck() -> InvokePrecheckResponse:
         if precheck_func:


### PR DESCRIPTION
- list available job types as list of strings
- relies on the app (in plugin repo called *Job class) has a property/attribute named "available_job_types"

This is intended to help workflow builder understand what options are available in a plugin that may have multiple job types. e.g., an embed plugin may have options for OpenAI, Bedrock, etc.