### PR TITLE
feat/pep-625 compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.13
+
+* **Conform to PEP-625 compliance for project naming**
+
 ## 0.0.12
 
 * **Bugfix: Fix UnrecoverableException exception handling to include full response**

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ def load_requirements(file: Union[str, Path]) -> List[str]:
 
 
 setup(
-    name="unstructured-platform-plugins",
+    name="unstructured_platform_plugins",
     version=__version__,
     description="A utility library that provides tools around unstructured plugin development",
     long_description=open("README.md", encoding="utf-8").read(),  # noqa: SIM115

--- a/unstructured_platform_plugins/__version__.py
+++ b/unstructured_platform_plugins/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.0.12"  # pragma: no cover
+__version__ = "0.0.13"  # pragma: no cover


### PR DESCRIPTION
### Description
Fixes the current issue from pypi:
> Specifically, your recent upload of 'unstructured-platform-plugins-0.0.12.tar.gz' is incompatible with PEP 625 because it does not contain the normalized project name 'unstructured_platform_plugins'.

This should not break anything using this library since this will only update the future release. 