### PR TITLE
bugfix/fix generating api when output has list union types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.17
+
+* **Bugfix supporting list union types in response**
+
 ## 0.0.16
 
 * **Bugfix for file data deserialization**

--- a/test/api/test_api.py
+++ b/test/api/test_api.py
@@ -38,15 +38,9 @@ mock_file_data = [
 ]
 
 
-@pytest.fixture
-def file_data() -> FileData:
-    return FileData(
-        identifier="mock file data",
-        connector_type="CON",
-        source_identifiers=SourceIdentifiers(filename="n", fullpath="n"),
-    )
-
-
+@pytest.mark.parametrize(
+    "file_data", mock_file_data, ids=[type(fd).__name__ for fd in mock_file_data]
+)
 def test_async_sample_function(file_data):
     from test.assets.async_typed_dict_response import async_sample_function as test_fn
 
@@ -62,6 +56,9 @@ def test_async_sample_function(file_data):
     assert output == {"response": {"a_out": 1, "b_out": 2}}
 
 
+@pytest.mark.parametrize(
+    "file_data", mock_file_data, ids=[type(fd).__name__ for fd in mock_file_data]
+)
 def test_dataclass_response(file_data):
     from test.assets.dataclass_response import sample_function_with_path as test_fn
 
@@ -85,6 +82,9 @@ def test_dataclass_response(file_data):
     }
 
 
+@pytest.mark.parametrize(
+    "file_data", mock_file_data, ids=[type(fd).__name__ for fd in mock_file_data]
+)
 def test_empty_input_and_output(file_data):
     from test.assets.empty_input_and_response import SampleClass as TestClass
 
@@ -99,6 +99,9 @@ def test_empty_input_and_output(file_data):
     assert not output
 
 
+@pytest.mark.parametrize(
+    "file_data", mock_file_data, ids=[type(fd).__name__ for fd in mock_file_data]
+)
 def test_filedata_meta(file_data):
     from test.assets.filedata_meta import Input
     from test.assets.filedata_meta import process_input as test_fn

--- a/test/assets/dataclass_response.py
+++ b/test/assets/dataclass_response.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Optional, TypedDict
+from typing import Any, Optional, TypedDict, Union
 
 from unstructured_ingest.v2.interfaces import BatchFileData, FileData
 
@@ -26,7 +26,7 @@ class SampleFunctionWithPathResponse:
 
 
 def sample_function_with_path(
-    file_data: FileData, b: str, c: int, a: Optional[Path] = None
+    file_data: Union[FileData, BatchFileData], b: str, c: int, a: Optional[Path] = None
 ) -> SampleFunctionWithPathResponse:
     s: list[Any] = [type(a).__name__, f"[exists: {a.exists()}]", a.resolve()] if a else []
     s.extend([b, c])

--- a/unstructured_platform_plugins/__version__.py
+++ b/unstructured_platform_plugins/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.0.16"  # pragma: no cover
+__version__ = "0.0.17"  # pragma: no cover


### PR DESCRIPTION
### Description
If the response type has typing data such as:
```python
@dataclass
class Response:
  data: list[Union[int, str]]
```
This causes an error. This PR adds support for that. 