### PR TITLE
handle errors in streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.23
+
+* **Handle errors in streaming responses**
+
 ## 0.0.22
 
 * **Bump `unstructured-ingest` to 0.4.0**

--- a/unstructured_platform_plugins/__version__.py
+++ b/unstructured_platform_plugins/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.0.22"  # pragma: no cover
+__version__ = "0.0.23"  # pragma: no cover

--- a/unstructured_platform_plugins/etl_uvicorn/api_generator.py
+++ b/unstructured_platform_plugins/etl_uvicorn/api_generator.py
@@ -168,7 +168,7 @@ def _wrap_in_fastapi(
                                 output=output,
                             ).model_dump_json() + "\n"
                     except Exception as e:
-                        logger.error(f"failed to stream response: {e}", exc_info=True)
+                        logger.error(f"Failure streaming response: {e}", exc_info=True)
                         yield InvokeResponse(
                             usage=usage,
                             filedata_meta=None,


### PR DESCRIPTION
This PR add error handling for streaming responses and passes and error code down.

This prevents weird buried unhandled exceptions obfuscating errors in the indexer.