### PR TITLE
bugfix/don't inclue message channels in input schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.25
+
+* **Remove message channels from input signature**
+
 ## 0.0.24
 
 * **Add support for passing messages back other than errors**

--- a/unstructured_platform_plugins/__version__.py
+++ b/unstructured_platform_plugins/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.0.24"  # pragma: no cover
+__version__ = "0.0.25"  # pragma: no cover

--- a/unstructured_platform_plugins/etl_uvicorn/api_generator.py
+++ b/unstructured_platform_plugins/etl_uvicorn/api_generator.py
@@ -142,7 +142,7 @@ def _wrap_in_fastapi(
         output: Optional[response_type] = None
         message_channels: MessageChannels = Field(default_factory=MessageChannels)
 
-    input_schema = get_input_schema(func, omit=["usage", "filedata_meta"])
+    input_schema = get_input_schema(func, omit=["usage", "filedata_meta", "message_channels"])
     input_schema_model = schema_to_base_model(input_schema)
 
     logging.getLogger("etl_uvicorn.fastapi")


### PR DESCRIPTION
### Description
Without this fix, it expects that the caller passes in a message channels object, even though this gets injected by the wrapper. This omits that. 