### PR TITLE
chore: remove calling `wrap_error` for `HTTPException`

### DIFF
--- a/unstructured_platform_plugins/__version__.py
+++ b/unstructured_platform_plugins/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.0.33"  # pragma: no cover
+__version__ = "0.0.34"  # pragma: no cover

--- a/unstructured_platform_plugins/etl_uvicorn/api_generator.py
+++ b/unstructured_platform_plugins/etl_uvicorn/api_generator.py
@@ -216,8 +216,8 @@ def _wrap_in_fastapi(
                 usage=usage,
                 message_channels=message_channels,
                 filedata_meta=filedata_meta_model.model_validate(filedata_meta.model_dump()),
-                status_code=wrap_error(exc).status_code,
-                status_code_text=f"[{exc.__class__.__name__}] {exc}",
+                status_code=exc.status_code,
+                status_code_text=exc.detail,
                 file_data=request_dict.get("file_data", None),
             )
         except UnrecoverableException as ex:

--- a/unstructured_platform_plugins/etl_uvicorn/errors.py
+++ b/unstructured_platform_plugins/etl_uvicorn/errors.py
@@ -20,9 +20,6 @@ class UserAuthError(UserError):
     status_code: int = 403
 
 
-class UnprocessableEntityError(UserError):
-    status_code: int = 422
-
 
 class RateLimitError(UserError):
     status_code: int = 429
@@ -36,24 +33,17 @@ class ProviderError(BaseError):
     status_code: int = 500
 
 
-class GatewayTimeoutError(BaseError):
-    status_code: int = 504
-
 
 class CatchAllError(BaseError):
     status_code: int = 512
 
 
 def wrap_error(e: Exception) -> HTTPException:
+    """
+    Wraps an exception in a HTTPException.
+    """
     if isinstance(e, ingest_errors.UserAuthError):
         return UserAuthError(e)
-    elif isinstance(e, HTTPException):
-        if e.status_code == 400:
-            return UserError(e)
-        if e.status_code == 422:
-            return UnprocessableEntityError(e)
-        if e.status_code == 504:
-            return GatewayTimeoutError(e)
     elif isinstance(e, ingest_errors.RateLimitError):
         return RateLimitError(e)
     elif isinstance(e, ingest_errors.QuotaError):

--- a/unstructured_platform_plugins/etl_uvicorn/errors.py
+++ b/unstructured_platform_plugins/etl_uvicorn/errors.py
@@ -20,7 +20,6 @@ class UserAuthError(UserError):
     status_code: int = 403
 
 
-
 class RateLimitError(UserError):
     status_code: int = 429
 
@@ -31,7 +30,6 @@ class QuotaError(UserError):
 
 class ProviderError(BaseError):
     status_code: int = 500
-
 
 
 class CatchAllError(BaseError):


### PR DESCRIPTION
we should not add each case for different HTTP status code -> should just raise one when we see one

`wrap_error` should only be called for `Exception`