### PR TITLE
fix(UNTRACKED): support `"none"` value for OTEL exporters to disable telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.42
+
+* **Support "none" value for OTEL_TRACES_EXPORTER and OTEL_METRICS_EXPORTER** - Filter "none" from exporter lists and return None when no exporters configured to properly disable OpenTelemetry instrumentation
+
 ## 0.0.39
 
 * **Remove wrap_error logic as exceptions are categorized in unstructured-ingest**

--- a/test/test_otel.py
+++ b/test/test_otel.py
@@ -1,0 +1,70 @@
+import pytest
+from opentelemetry.environment_variables import OTEL_METRICS_EXPORTER, OTEL_TRACES_EXPORTER
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.trace import TracerProvider
+
+from unstructured_platform_plugins.etl_uvicorn.otel import (
+    get_metric_provider,
+    get_settings,
+    get_trace_provider,
+)
+
+
+def test_get_settings_filters_none_from_traces(monkeypatch):
+    monkeypatch.setenv(OTEL_TRACES_EXPORTER, "none")
+    settings = get_settings()
+    assert settings["trace_exporters"] == []
+
+
+def test_get_settings_filters_none_from_metrics(monkeypatch):
+    monkeypatch.setenv(OTEL_METRICS_EXPORTER, "none")
+    settings = get_settings()
+    assert settings["metric_exporters"] == []
+
+
+def test_get_settings_filters_none_from_combined_trace_exporters(monkeypatch):
+    monkeypatch.setenv(OTEL_TRACES_EXPORTER, "none,console")
+    settings = get_settings()
+    assert settings["trace_exporters"] == ["console"]
+
+
+def test_get_settings_filters_none_from_combined_metric_exporters(monkeypatch):
+    monkeypatch.setenv(OTEL_METRICS_EXPORTER, "none,console")
+    settings = get_settings()
+    assert settings["metric_exporters"] == ["console"]
+
+
+def test_get_trace_provider_returns_none_when_exporter_is_none(monkeypatch):
+    monkeypatch.setenv(OTEL_TRACES_EXPORTER, "none")
+    assert get_trace_provider() is None
+
+
+def test_get_metric_provider_returns_none_when_exporter_is_none(monkeypatch):
+    monkeypatch.setenv(OTEL_METRICS_EXPORTER, "none")
+    assert get_metric_provider() is None
+
+
+def test_get_trace_provider_returns_provider_when_exporter_set(monkeypatch):
+    monkeypatch.setenv(OTEL_TRACES_EXPORTER, "console")
+    provider = get_trace_provider()
+    assert isinstance(provider, TracerProvider)
+
+
+def test_get_metric_provider_returns_provider_when_exporter_set(monkeypatch):
+    monkeypatch.setenv(OTEL_METRICS_EXPORTER, "console")
+    provider = get_metric_provider()
+    assert isinstance(provider, MeterProvider)
+
+
+def test_wrap_in_fastapi_does_not_crash_with_none_otel_exporters(monkeypatch):
+    """Regression: previously crashed with NotImplementedError when none was set."""
+    monkeypatch.setenv(OTEL_TRACES_EXPORTER, "none")
+    monkeypatch.setenv(OTEL_METRICS_EXPORTER, "none")
+
+    from test.assets.async_typed_dict_response import async_sample_function
+
+    from unstructured_platform_plugins.etl_uvicorn.api_generator import wrap_in_fastapi
+
+    # Should not raise NotImplementedError
+    app = wrap_in_fastapi(func=async_sample_function, plugin_id="test_plugin")
+    assert app is not None

--- a/test/test_otel.py
+++ b/test/test_otel.py
@@ -1,4 +1,3 @@
-import pytest
 from opentelemetry.environment_variables import OTEL_METRICS_EXPORTER, OTEL_TRACES_EXPORTER
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.trace import TracerProvider
@@ -62,7 +61,6 @@ def test_wrap_in_fastapi_does_not_crash_with_none_otel_exporters(monkeypatch):
     monkeypatch.setenv(OTEL_METRICS_EXPORTER, "none")
 
     from test.assets.async_typed_dict_response import async_sample_function
-
     from unstructured_platform_plugins.etl_uvicorn.api_generator import wrap_in_fastapi
 
     # Should not raise NotImplementedError

--- a/unstructured_platform_plugins/__version__.py
+++ b/unstructured_platform_plugins/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.0.41"  # pragma: no cover
+__version__ = "0.0.42"  # pragma: no cover


### PR DESCRIPTION
## Problem

When `OTEL_TRACES_EXPORTER=none` or `OTEL_METRICS_EXPORTER=none` is set, plugin pods crash on startup with:

### Real-world scenario
In in-vpc or single-node clusters, you might notice this issue in plugin pods (created by the job-execution-operator) when you set those environment variables in the `JOB_ENV_VARS` block.

https://github.com/Unstructured-IO/platform-applications-cd/blob/9cf7335f3fe620106c61da208c12d44539d743bc/apps/dataplane/etl-operator/values.yaml#L52

```
NotImplementedError: none implementation not supported yet
```

**Root cause:** The code splits the env var by comma but doesn't filter "none", then tries to initialize exporters for it, hitting the `NotImplementedError` in `_add_trace_exporter()` and `_get_metrics_reader()`.

## Solution

### 1. Filter "none" from exporter lists (lines 33, 37)
```python
trace_exporters = [e for e in trace_exporters if e != "none"]
metric_exporters = [e for e in metric_exporters if e != "none"]
```

### 2. Return None when no exporters configured (lines 45-49, 59-63)
```python
def get_trace_provider() -> TracerProvider | None:
    settings = get_settings()
    if not settings["trace_exporters"]:
        return None  # Let OTEL SDK use default no-op
    ...
```

## Compatibility

`FastAPIInstrumentor.instrument_app()` explicitly supports `None` values for `tracer_provider` and `meter_provider` parameters (defaults to None). When None, OTEL SDK uses its built-in no-op providers.

## Testing

**Before:** Plugin crashes with `NotImplementedError`
**After:** Plugin starts successfully with telemetry disabled

## Changes

- Filter "none" from OTEL_TRACES_EXPORTER and OTEL_METRICS_EXPORTER env vars
- Return None from get_trace_provider/get_metric_provider when exporters list empty
- Bump version 0.0.41 → 0.0.42
- Update CHANGELOG.md

## Deployment

1. After merge, we need to rebuild platform-plugins images (auto-picks latest version)
2. Cut a new platform release