### PR TITLE
feat(etl-uvicorn): ignore SIGTERM in plugin uvicorn Server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.0.44
+
+* **Ignore SIGTERM in plugin uvicorn Servers**: plugin webservers now keep
+  serving on SIGTERM so their controller container can finish dispatching
+  in-flight work before the pod is SIGKILLed. SIGINT still terminates for
+  local-dev Ctrl-C.
+
 ## 0.0.43
 
 * **Deprecate `wrap_in_fastapi`** - Mark `wrap_in_fastapi` (and the `etl-uvicorn` CLI it backs) as deprecated via PEP 702 `@deprecated`. New plugins should build a FastAPI app directly with explicit handlers for the plugin contract routes.

--- a/test/test_signal_handlers.py
+++ b/test/test_signal_handlers.py
@@ -1,0 +1,35 @@
+"""Verify the etl_uvicorn module installs a SIGTERM-ignoring handler on uvicorn.Server."""
+
+import asyncio
+import signal
+
+import uvicorn
+
+# Importing the module applies the monkey-patch as a side effect.
+from unstructured_platform_plugins.etl_uvicorn import main  # noqa: F401
+
+
+def test_uvicorn_server_install_signal_handlers_is_patched():
+    assert (
+        uvicorn.Server.install_signal_handlers.__name__
+        == "_install_signal_handlers_ignoring_sigterm"
+    )
+
+
+def test_install_signal_handlers_registers_sigint_only():
+    async def _run() -> None:
+        config = uvicorn.Config(app="fake:app", lifespan="off")
+        server = uvicorn.Server(config=config)
+        server.install_signal_handlers()
+        loop = asyncio.get_running_loop()
+        try:
+            assert loop.remove_signal_handler(signal.SIGINT) is True
+            assert loop.remove_signal_handler(signal.SIGTERM) is False
+        finally:
+            try:
+                loop.remove_signal_handler(signal.SIGINT)
+                loop.remove_signal_handler(signal.SIGTERM)
+            except Exception:
+                pass
+
+    asyncio.run(_run())

--- a/unstructured_platform_plugins/__version__.py
+++ b/unstructured_platform_plugins/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.0.43"  # pragma: no cover
+__version__ = "0.0.44"  # pragma: no cover

--- a/unstructured_platform_plugins/etl_uvicorn/main.py
+++ b/unstructured_platform_plugins/etl_uvicorn/main.py
@@ -1,11 +1,32 @@
+import asyncio
+import signal
+import threading
 from dataclasses import dataclass, field
 from typing import IO, Any, Optional
 
 import click
+import uvicorn
 from uvicorn.config import LOGGING_CONFIG, Config, RawConfigParser
 from uvicorn.main import main, run
 
 from unstructured_platform_plugins.etl_uvicorn.api_generator import generate_fast_api
+
+
+def _install_signal_handlers_ignoring_sigterm(self: uvicorn.Server) -> None:
+    # uvicorn's default load-sheds 504 on SIGTERM, which races with controllers
+    # trying to drain in-flight work during pod shutdown. Plugin webservers are
+    # expected to outlive their controller container so SIGKILL — not SIGTERM —
+    # ends the process. SIGINT is preserved so local Ctrl-C still works.
+    if threading.current_thread() is not threading.main_thread():
+        return
+    try:
+        loop = asyncio.get_event_loop()
+        loop.add_signal_handler(signal.SIGINT, self.handle_exit, signal.SIGINT, None)
+    except NotImplementedError:
+        signal.signal(signal.SIGINT, self.handle_exit)
+
+
+uvicorn.Server.install_signal_handlers = _install_signal_handlers_ignoring_sigterm
 
 
 @dataclass


### PR DESCRIPTION
## Summary

uvicorn's default SIGTERM behavior load-sheds new requests with 504 while draining in-flight work. Plugin webservers in our platform are expected to **outlive their controller container** during pod shutdown so the controller can finish dispatching in-flight work before the pod is SIGKILLed — the default behavior races with that drain and orphans records.

This PR monkey-patches `uvicorn.Server.install_signal_handlers` at module import time so plugin webservers using `etl-uvicorn` install only a SIGINT handler. The process now ignores SIGTERM and exits only on SIGKILL (or SIGINT for local-dev Ctrl-C).

## Why a monkey-patch instead of a Server subclass?

Subclassing requires bypassing `uvicorn.run()` and manually constructing `Config + Server`, which loses uvicorn's built-in handling of workers / reload / multiproc. Plugin webservers don't use those today but the surface area isn't worth changing. The patch is 8 lines, well-scoped to module import, and works for any uvicorn.Server instance in this process.

## Test plan

- [x] `make tidy` — clean
- [x] `make check-ruff` — passes
- [x] `pytest` — all tests pass (existing suite + 2 new in `test/test_signal_handlers.py` covering the patch is applied + the SIGINT-only handler set)
- [ ] Smoke test: send SIGTERM to a plugin pod, confirm the process keeps serving until SIGKILL at end of pod grace
- [ ] Verify plugin logs / traces show no 504s from `/invoke` during a rolling deploy after this version is rolled out

## Version

Bumps `unstructured_platform_plugins` to `0.0.44`. Downstream consumers will need a separate change to pin the new version.