### PR TITLE
chore: deprecate wrap_in_fastapi via PEP 702 @deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.43
+
+* **Deprecate `wrap_in_fastapi`** - Mark `wrap_in_fastapi` (and the `etl-uvicorn` CLI it backs) as deprecated via PEP 702 `@deprecated`. New plugins should hand-roll their own FastAPI app — see the `chunker` plugin in `platform-plugins` for the reference pattern.
+
 ## 0.0.42
 
 * **Support "none" value for OTEL_TRACES_EXPORTER and OTEL_METRICS_EXPORTER** - Filter "none" from exporter lists and return None when no exporters configured to properly disable OpenTelemetry instrumentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.0.43
 
-* **Deprecate `wrap_in_fastapi`** - Mark `wrap_in_fastapi` (and the `etl-uvicorn` CLI it backs) as deprecated via PEP 702 `@deprecated`. New plugins should hand-roll their own FastAPI app — see the `chunker` plugin in `platform-plugins` for the reference pattern.
+* **Deprecate `wrap_in_fastapi`** - Mark `wrap_in_fastapi` (and the `etl-uvicorn` CLI it backs) as deprecated via PEP 702 `@deprecated`. New plugins should build a FastAPI app directly with explicit handlers for the plugin contract routes.
 
 ## 0.0.42
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,8 @@
  ![CI](https://github.com/Unstructured-IO/unstructured-platform-plugins/actions/workflows/ci.yml/badge.svg?branch=main)
 
 > **Deprecation notice:** `wrap_in_fastapi` (and the `etl-uvicorn` CLI it backs)
-> is deprecated. New plugins should hand-roll their own FastAPI app with
-> explicit `/invoke`, `/schema`, `/precheck`, `/id`, and `/ready` handlers.
-> The `chunker` plugin in `platform-plugins` is the reference pattern.
+> is deprecated. New plugins should build a FastAPI app directly with explicit
+> handlers for the plugin contract routes (`/invoke`, `/schema`, `/id`, etc.).
 
 Information about how to build custom plugins to integrate with Unstructured Platform.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Unstructured Platform Plugins
  ![CI](https://github.com/Unstructured-IO/unstructured-platform-plugins/actions/workflows/ci.yml/badge.svg?branch=main)
 
+> **Deprecation notice:** `wrap_in_fastapi` (and the `etl-uvicorn` CLI it backs)
+> is deprecated. New plugins should hand-roll their own FastAPI app with
+> explicit `/invoke`, `/schema`, `/precheck`, `/id`, and `/ready` handlers.
+> The `chunker` plugin in `platform-plugins` is the reference pattern.
+
 Information about how to build custom plugins to integrate with Unstructured Platform.
 
 ## Plugin Development

--- a/unstructured_platform_plugins/__version__.py
+++ b/unstructured_platform_plugins/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.0.42"  # pragma: no cover
+__version__ = "0.0.43"  # pragma: no cover

--- a/unstructured_platform_plugins/etl_uvicorn/api_generator.py
+++ b/unstructured_platform_plugins/etl_uvicorn/api_generator.py
@@ -110,9 +110,8 @@ def update_filedata_model(new_type) -> BaseModel:
 
 
 @deprecated(
-    "wrap_in_fastapi is deprecated; hand-roll a FastAPI app instead. "
-    "See platform_plugins/plugins/chunker for the reference pattern "
-    "(explicit /invoke, /schema, /precheck, /id, /ready handlers)."
+    "wrap_in_fastapi is deprecated; build a FastAPI app directly with "
+    "explicit handlers for the plugin contract routes."
 )
 def wrap_in_fastapi(
     func: Callable,

--- a/unstructured_platform_plugins/etl_uvicorn/api_generator.py
+++ b/unstructured_platform_plugins/etl_uvicorn/api_generator.py
@@ -11,6 +11,7 @@ from fastapi.responses import StreamingResponse
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from pydantic import BaseModel, Field, create_model
 from starlette.responses import RedirectResponse
+from typing_extensions import deprecated
 from unstructured_ingest.data_types.file_data import BatchFileData, FileData, file_data_from_dict
 from unstructured_ingest.error import UnstructuredIngestError
 from uvicorn.config import LOG_LEVELS
@@ -108,6 +109,11 @@ def update_filedata_model(new_type) -> BaseModel:
     return new_filedata_model
 
 
+@deprecated(
+    "wrap_in_fastapi is deprecated; hand-roll a FastAPI app instead. "
+    "See platform_plugins/plugins/chunker for the reference pattern "
+    "(explicit /invoke, /schema, /precheck, /id, /ready handlers)."
+)
 def wrap_in_fastapi(
     func: Callable,
     plugin_id: str,


### PR DESCRIPTION
## Summary

- Mark `wrap_in_fastapi` (and the `etl-uvicorn` CLI it backs) as deprecated using `typing_extensions.deprecated` (PEP 702).
- Add a deprecation banner to `README.md` pointing users at building a FastAPI app directly.
- Add a `CHANGELOG.md` entry and bump version `0.0.42` → `0.0.43`.

## Why

The wrapper obfuscates the mental model of what a plugin actually is. By auto-generating routes from a Python function's signature, plugin authors never have to engage with the HTTP contract the platform actually depends on — which routes exist, what they return, when each one is called. Authors end up reasoning about "my `run()` function" instead of "my plugin's API surface," and that gap shows up the moment the contract evolves and the helper doesn't keep up.

Encoding the deprecation in code rather than tribal knowledge means:

- IDEs and type-checkers (pyright/mypy) show strikethrough at every call site and import, nudging plugin authors at edit time.
- `ruff` recognizes the decorator via `DeprecationWarning`.
- Test suites that don't suppress `DeprecationWarning` (pytest default) emit one warning per call.

## Noise expectations

- **Production**: effectively zero — Python's default warnings filter suppresses `DeprecationWarning` from non-`__main__` modules.
- **CI / pytest**: one warning per `wrap_in_fastapi` call. Verified locally: 68 tests pass, 7 distinct call sites emit the warning.
- **Editor / type-checker**: persistent strikethrough — this is the channel that does the actual nudging.

## Test plan

- [x] `make check-ruff` passes
- [x] `PYTHONPATH=. pytest test/` — 68 passed
- [x] Verified `DeprecationWarning` fires from `wrap_in_fastapi` call sites in tests