### PR TITLE
feat: expose check as precheck alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.45
+
+* **Add `/check` as the plugin connection-check route**: generated plugin apps now expose `/check` alongside `/precheck` for the v3 plugin contract.
+
 ## 0.0.44
 
 * **Ignore SIGTERM in plugin uvicorn Servers**: plugin webservers now keep

--- a/test/api/test_api.py
+++ b/test/api/test_api.py
@@ -44,6 +44,15 @@ mock_file_data = [
 ]
 
 
+def test_check_alias_matches_precheck_noop_response():
+    from test.assets.empty_input_and_response import SampleClass as TestClass
+
+    test_class = TestClass()
+    client = TestClient(wrap_in_fastapi(func=test_class.do_nothing, plugin_id="mock_plugin"))
+
+    assert client.get("/check").json() == client.get("/precheck").json()
+
+
 @pytest.mark.parametrize(
     "file_data", mock_file_data, ids=[type(fd).__name__ for fd in mock_file_data]
 )

--- a/unstructured_platform_plugins/__version__.py
+++ b/unstructured_platform_plugins/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.0.44"  # pragma: no cover
+__version__ = "0.0.45"  # pragma: no cover

--- a/unstructured_platform_plugins/etl_uvicorn/api_generator.py
+++ b/unstructured_platform_plugins/etl_uvicorn/api_generator.py
@@ -299,7 +299,6 @@ def _wrap_in_fastapi(
         resp = SchemaOutputResponse(inputs=schema["inputs"], outputs=schema["outputs"])
         return resp
 
-    @fastapi_app.get("/precheck")
     async def run_precheck() -> InvokePrecheckResponse:
         if precheck_func:
             fn_response = await wrap_fn(func=precheck_func)
@@ -310,6 +309,9 @@ def _wrap_in_fastapi(
             )
         else:
             return InvokePrecheckResponse(status_code=status.HTTP_200_OK, usage=[])
+
+    fastapi_app.get("/check")(run_precheck)
+    fastapi_app.get("/precheck")(run_precheck)
 
     @fastapi_app.get("/id")
     async def get_id() -> str:


### PR DESCRIPTION
## Summary
- Register generated plugin `/check` routes against the same handler as `/precheck`
- Preserve `/precheck` compatibility while allowing runtimes to call `/check`
- Add API test coverage for the alias behavior

## Testing
- Not run in this checkout


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured-platform-plugins/pull/71?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

