### PR TITLE
chore(etl-uvicorn): prepare 0.0.46 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.0.46
+
+* **Carry preflight failure categories through standard `/precheck` responses.**
+  `InvokeResponse` and `InvokePrecheckResponse` now expose an optional `failure_category`
+  copied from a raised error, allowing plugins to preserve the centralized preflight
+  taxonomy through the normal `precheck_func` route wiring. Successful responses leave
+  the field unset.
+
 ## 0.0.45
 
 * **`/invoke` no longer demands a body from a plugin whose parameters are all optional.** A pydantic

--- a/unstructured_platform_plugins/__version__.py
+++ b/unstructured_platform_plugins/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.0.45"  # pragma: no cover
+__version__ = "0.0.46"  # pragma: no cover


### PR DESCRIPTION
## Summary
- bump `unstructured-platform-plugins` from `0.0.45` to `0.0.46`
- document the `failure_category` response plumbing merged in #77

## Why
`Unstructured-IO/platform-plugins#1780` depends on #77 and currently uses a temporary git source. Publishing `0.0.46` lets it return to a released package constraint.

## Validation
- `make check` — passed
- `PYTHONPATH=. uv run --group test pytest -q` — 93 passed
- confirmed the changelog and package version both report `0.0.46`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Unstructured-IO/unstructured-platform-plugins/pull/78?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

